### PR TITLE
Allow php configuration by environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You can configure the database connection using environment variables instead of
 | APPLICATION_ENV         | App mode: development or production    | production   |
 | OMEKA_THEMES            | List of theme zip URLs                 |              |
 | OMEKA_MODULES           | List of module zip URLs                |              |
+| PHP_MEMORY_LIMIT        | PHP memory limit (e.g. 512M)           | 128M         |
+| PHP_UPLOAD_MAX_FILESIZE | Max upload file size (e.g. 50M)        | 2M           |
+| PHP_POST_MAX_SIZE       | Max post size (e.g. 60M)               | 8M           |
+| PHP_MAX_EXECUTION_TIME  | Max script execution time (seconds)    | 30           |
 
 ## Docker Hub
 

--- a/docker-compose_local_example.yml
+++ b/docker-compose_local_example.yml
@@ -22,6 +22,11 @@ services:
         https://github.com/Daniel-KM/Omeka-S-module-Common/releases/download/3.4.66/Common-3.4.66.zip      
         https://github.com/Daniel-KM/Omeka-S-module-EasyAdmin/releases/download/3.4.29/EasyAdmin-3.4.29.zip
         https://github.com/Daniel-KM/Omeka-S-module-Adminer/releases/download/3.4.5-4.8.4/Adminer-3.4.5-4.8.4.zip
+      PHP_MEMORY_LIMIT: 512M
+      PHP_UPLOAD_MAX_FILESIZE: 50M
+      PHP_POST_MAX_SIZE: 60M
+      PHP_MAX_EXECUTION_TIME: 90
+
     volumes:
       - omekas:/var/www/html/volume:Z
 

--- a/docker-compose_traefik_example.yml
+++ b/docker-compose_traefik_example.yml
@@ -62,7 +62,11 @@ services:
       MYSQL_DATABASE: secretstring #FIXME
       MYSQL_HOST: omekas_db
       APPLICATION_ENV: production
-      OMEKA_THEMES: https://github.com/omeka-s-themes/default/releases/download/v1.9.1/theme-default-v1.9.1.zip
+      OMEKA_THEMES: https://github.com/omeka-s-themes/default/releases/download/v1.9.1/theme-default-v1.9.1.zip  
+      PHP_MEMORY_LIMIT: 512M
+      PHP_UPLOAD_MAX_FILESIZE: 50M
+      PHP_POST_MAX_SIZE: 60M
+      PHP_MAX_EXECUTION_TIME: 90
     networks:
       - network1
     links:

--- a/docker-php-entrypoint
+++ b/docker-php-entrypoint
@@ -81,6 +81,20 @@ else
   echo "No module URLs provided. Skipping module installation."
 fi
 
+# Generate PHP custom config based on environment variables
+PHP_CUSTOM_INI="$PHP_INI_DIR/conf.d/docker-php-custom.ini"
+
+{
+  echo "; Custom PHP settings from environment"
+  echo "memory_limit = ${PHP_MEMORY_LIMIT:-128M}"
+  echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE:-2M}"
+  echo "post_max_size = ${PHP_POST_MAX_SIZE:-8M}"
+  echo "max_execution_time = ${PHP_MAX_EXECUTION_TIME:-30}"
+} > "$PHP_CUSTOM_INI"
+
+echo "[Entrypoint] Using custom PHP configuration:"
+cat "$PHP_CUSTOM_INI"
+
 # Run the original Docker PHP entrypoint (ref. file https://github.com/docker-library/php/blob/master/8.2/bookworm/apache/docker-php-entrypoint)
 # first argument is `-f` or another option
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
This pull request introduces configurable PHP settings via environment variables for Docker-based deployments. It includes updates to documentation, example `docker-compose` files, and the PHP entrypoint script to support these new options.

### Documentation Updates:
* Added descriptions for new environment variables (`PHP_MEMORY_LIMIT`, `PHP_UPLOAD_MAX_FILESIZE`, `PHP_POST_MAX_SIZE`, `PHP_MAX_EXECUTION_TIME`) to the `README.md`. These variables allow customization of PHP settings such as memory limit, upload file size, post size, and script execution time.

### Docker Compose Enhancements:
* Updated `docker-compose_local_example.yml` and `docker-compose_traefik_example.yml` to include default values for the new PHP environment variables. These changes provide examples of how to set these configurations in local and production-like environments. [[1]](diffhunk://#diff-8764ada975474f5c9125aaf59c160854bbe21e91ee013b34c244b0e197218effR25-R29) [[2]](diffhunk://#diff-1408de2f2e68e71eaef4e75487983008516fd02f72c4fa9af3cd3c36cd6e8cb8R66-R69)

### Entrypoint Script Improvements:
* Modified the `docker-php-entrypoint` script to dynamically generate a custom PHP configuration file (`docker-php-custom.ini`) based on the new environment variables. This ensures that the PHP runtime is configured as per user-defined settings.